### PR TITLE
Kinesis Handler module, with a synchronous one and one not

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,4 +15,3 @@ plugins:
 env:
   es6: true
   node: true
-parser: babel-eslint

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -80,11 +80,17 @@ function KinesisHandler(eventSchema, moduleName) {
   /**
    * Registers a schema and method pair.
    * @param schema The json schema for the data that triggers the calling of the provided method.
-   * @param method The method to invoke on validating to the given schema, must be of the form (event, complete) => {}.  TODO enforce this.
+   * @param method The method to invoke on validating to the given schema, must be of the form (event, callback) => {}.
    */
   this.registerSchemaMethodPair = function (schema, method) {
     const schemaId = makeSchemaId(schema)
     this.ajv.addSchema(schema, schemaId)
+
+    if (typeof method !== 'function' || method.length !== 2) {
+      throw new Error('Method must be a function of the form (event, callback) => { . . . }')
+    } else { // TODO remove
+      console.log(`OK: Method for ${schemaId} is a function with two parameters.`)
+    }
     this.schemaMethodPairs[schemaId] = method
   }
 
@@ -108,7 +114,6 @@ function KinesisHandler(eventSchema, moduleName) {
         this.schemaMethodPairs[event.data.schema](event, complete)
       }
     } else {
-      // TODO remove console.log and pass the above message once we are only receiving subscribed events
       console.log(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} - event with unsupported data schema (${event.data.schema}) observed.`)
       complete()
     }
@@ -132,9 +137,6 @@ function KinesisHandler(eventSchema, moduleName) {
         const complete = (err) => {
           if (err) {
             console.log(err)
-            // TODO uncomment following
-            // throw new Error(`${this.module} ${err}`);
-            // TODO remove rest of block to use above.
             const msg = `${this.module} ${err}`
             if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
               console.log('######################################################################################')
@@ -208,11 +210,17 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
   /**
    * Registers a schema and method pair.
    * @param schema The json schema for the data that triggers the calling of the provided method.
-   * @param method The method to invoke on validating to the given schema, must be of the form (event, complete) => {}.  TODO enforce this.
+   * @param method The method to invoke on validating to the given schema, must be of the form (event, complete) => {}.
    */
   this.registerSchemaMethodPair = function (schema, method) {
     const schemaId = makeSchemaId(schema)
     this.ajv.addSchema(schema, schemaId)
+
+    if (typeof method !== 'function' || method.length !== 2) {
+      throw new Error('Method must be a function of the form (event, callback) => { . . . }')
+    } else { // TODO remove
+      console.log(`OK: Method for ${schemaId} is a function with two parameters.`)
+    }
     this.schemaMethodPairs[schemaId] = method
   }
 

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -55,7 +55,7 @@ function makeSchemaId(schema) {
  *   ]
  * }
  * Creates Kinesis Handler instance.
- * Usage: `KinesisHandler(eventSchema, parallel)`
+ * Usage: `KinesisHandler(eventSchema, synch, moduleName)`
  * @param eventSchema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
  * @param synch Default is false.  If true, process batches of Kinesis events synchronously, maintaining the order within each batch.  Otherwise, process batches asynchronously, in parallel.
  * @param moduleName The name by which the module instantiating this instance is referred to in error messages.

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const AJV = require('ajv')
-const aws = require('aws-sdk')
 
 const constants = {
   // generic reference to self in error messages
@@ -16,8 +15,6 @@ const constants = {
 function makeSchemaId(schema) {
   return `${schema.self.vendor}/${schema.self.name}/${schema.self.version}`
 }
-
-module.exports = KinesisHandler
 
 /**
  * Example Kinesis Event Batch:
@@ -58,30 +55,26 @@ module.exports = KinesisHandler
  *   ]
  * }
  * Creates Kinesis Handler instance.
- * Usage: `KinesisHandler(schema, parallel)`
- * @param schema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
+ * Usage: `KinesisHandler(eventSchema, parallel)`
+ * @param eventSchema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
  * @param synch Default is false.  If true, process batches of Kinesis events synchronously, maintaining the order within each batch.  Otherwise, process batches asynchronously, in parallel.
  * @param moduleName The name by which the module instantiating this instance is referred to in error messages.
  * @return {Object} Kinesis handler instance
  */
-function KinesisHandler(schema, synch, moduleName) {
-  if (!schema) {
+function KinesisHandler(eventSchema, synch, moduleName) {
+  if (!eventSchema) {
     throw new Error('A schema for the event data on the Kinesis stream must be provided to this handler.')
   }
 
   // set parameters as configured for the instance and initialize pairs mapping for the instance
-  this.eventSchemaId = makeSchemaId(schema)
+  this.eventSchemaId = makeSchemaId(eventSchema)
   this.synch = synch
   this.module = moduleName && (moduleName !== '') ? moduleName : this.module
   this.schemaMethodPairs = {}
 
   // set up validator and add event schema to validator
   this.ajv = new AJV()
-  this.ajv.addSchema(schema, this.eventSchemaId)
-
-  // attach methods directly called by instantiator
-  this.registerSchemaMethodPair = registerSchemaMethodPair
-  this.handler = processKinesisEvent
+  this.ajv.addSchema(eventSchema, this.eventSchemaId)
 
   /**
    * Registers a schema and method pair.
@@ -104,11 +97,11 @@ function KinesisHandler(schema, synch, moduleName) {
       complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not specify a schema.`)
     } else if (event.schema !== this.eventSchemaId) {
       complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not have proper schema.  Observed: '${event.schema}' expected: '${this.eventSchemaId}'`)
-    } else if (!ajv.validate(this.eventSchemaId, event)) {
-      complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${this.eventSchemaId}' schema.  Errors: ${ajv.errorsText()}`)
+    } else if (!this.ajv.validate(this.eventSchemaId, event)) {
+      complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${this.eventSchemaId}' schema.  Errors: ${this.ajv.errorsText()}`)
     } else if (Object.keys(this.schemaMethodPairs).indexOf(event.data.schema) > -1) {
-      if (!ajv.validate(event.data.schema, event.data)) {
-        complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${event.data.schema}' schema. Errors: ${ajv.errorsText()}`)
+      if (!this.ajv.validate(event.data.schema, event.data)) {
+        complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${event.data.schema}' schema. Errors: ${this.ajv.errorsText()}`)
       } else {
         this.schemaMethodPairs[event.data.schema](event, complete)
       }
@@ -119,75 +112,80 @@ function KinesisHandler(schema, synch, moduleName) {
     }
   }
 
-    /**
-     * @param kinesisEvent The Kinesis event to decode and process.
-     * @param context The Lambda context object.
-     * @param callback The callback with which to call with results of event processing.
-     */
-    function processKinesisEvent(kinesisEvent, context, callback) {
-      if (this.synch) {
-        console.log('TODO implement synchronous batch handling.')
-      } else {
-        try {
-          console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
-          if (
-            kinesisEvent &&
-            kinesisEvent.Records &&
-            Array.isArray(kinesisEvent.Records)
-          ) {
-            let successes = 0
-            const complete = (err) => {
-              if (err) {
-                console.log(err)
-                // TODO uncomment following
-                // throw new Error(`${this.module} ${err}`);
-                // TODO remove rest of block to use above.
-                const msg = `${this.module} ${err}`
-                if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
-                  console.log('######################################################################################')
-                  console.log(msg)
-                  console.log('######################################################################################')
-                  successes += 1
-                } else {
-                  throw new Error(msg)
-                }
-              } else {
+  /**
+   * @param kinesisEvent The Kinesis event to decode and process.
+   * @param context The Lambda context object.
+   * @param callback The callback with which to call with results of event processing.
+   */
+  function processKinesisEvent(kinesisEvent, context, callback) {
+    if (this.synch) {
+      console.log('TODO implement synchronous batch handling.')
+    } else {
+      try {
+        console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
+        if (
+          kinesisEvent &&
+          kinesisEvent.Records &&
+          Array.isArray(kinesisEvent.Records)
+        ) {
+          let successes = 0
+          const complete = (err) => {
+            if (err) {
+              console.log(err)
+              // TODO uncomment following
+              // throw new Error(`${this.module} ${err}`);
+              // TODO remove rest of block to use above.
+              const msg = `${this.module} ${err}`
+              if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
+                console.log('######################################################################################')
+                console.log(msg)
+                console.log('######################################################################################')
                 successes += 1
-              }
-              if (successes === kinesisEvent.Records.length) {
-                console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
-                callback()
-              }
-            }
-            for (let i = 0; i < kinesisEvent.Records.length; i++) {
-              const record = kinesisEvent.Records[i]
-              if (
-                record.kinesis &&
-                record.kinesis.data
-              ) {
-                let parsed
-                try {
-                  const payload = new Buffer(record.kinesis.data, 'base64').toString()
-                  console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
-                  parsed = JSON.parse(payload)
-                } catch (ex) {
-                  complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
-                }
-                if (parsed) {
-                  impl.processEvent(parsed, complete)
-                }
               } else {
-                complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
+                throw new Error(msg)
               }
+            } else {
+              successes += 1
             }
-          } else {
-            callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
+            if (successes === kinesisEvent.Records.length) {
+              console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
+              callback()
+            }
           }
-        } catch (ex) {
-          console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
-          callback(ex)
+          for (let i = 0; i < kinesisEvent.Records.length; i++) {
+            const record = kinesisEvent.Records[i]
+            if (
+              record.kinesis &&
+              record.kinesis.data
+            ) {
+              let parsed
+              try {
+                const payload = new Buffer(record.kinesis.data, 'base64').toString()
+                console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
+                parsed = JSON.parse(payload)
+              } catch (ex) {
+                complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
+              }
+              if (parsed) {
+                processEvent(parsed, complete)
+              }
+            } else {
+              complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
+            }
+          }
+        } else {
+          callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
         }
+      } catch (ex) {
+        console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
+        callback(ex)
       }
     }
+  }
+
+  // attach methods directly called by instantiator
+  this.registerSchemaMethodPair = registerSchemaMethodPair
+  this.handler = processKinesisEvent
 }
 
+module.exports = KinesisHandler

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -217,9 +217,8 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
   }
 
   /**
-   * Process the given event, reporting any error through the iterator.  Called by a generator.
+   * Process the given event, passing back any non-fatal (data-quality) errors to the iterator that called it.
    * @param event The event to validate and process with the appropriate logic
-   * @param complete The callback with which to report any errors
    */
   this.processEvent = function (event) {
     const that = this
@@ -239,7 +238,7 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
             console.log('Fatal error while processing. ', err)
             throw new Error(`${this.module} ${err}`) // could have the iterator throw this back to yield, but not much point having it there than here, since these are not being handled (except by re-try)
           } else {
-            // console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
+            console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - one ${event.data.schema} event processed successfully.`)
             that.it.next()
           }
         })
@@ -251,6 +250,39 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
         that.it.next()
       }, 0)
     }
+  }
+
+  /**
+   * Generates an iterator to synchronously process each record in the batch with the given logic (parse, process, collect bad messages)
+   * @param kinesisEvent The batch of events to validate and process with the generated iterator
+   */
+  this.recordGenerator = function* (kinesisEvent) {
+    const badMessages = [] // bad in the sense that they failed for validation or data quality reasons, but not a fatal error that would cause a re-try, such as an error while interacting with an AWS resource
+    for (let i = 0; i < kinesisEvent.Records.length; i++) {
+      const record = kinesisEvent.Records[i]
+      if (
+        record.kinesis &&
+        record.kinesis.data
+      ) {
+        let parsed
+        try {
+          const payload = new Buffer(record.kinesis.data, 'base64').toString()
+          console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
+          parsed = JSON.parse(payload)
+        } catch (ex) {
+          badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
+        }
+        if (parsed) {
+          const recordError = yield this.processEvent(parsed)
+          if (recordError) {
+            badMessages.push(recordError)
+          }
+        }
+      } else {
+        badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
+      }
+    }
+    console.log('Messages with invalid data: ', badMessages)
   }
 
   /**
@@ -266,34 +298,7 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
         kinesisEvent.Records &&
         Array.isArray(kinesisEvent.Records)
       ) {
-        const badMessages = [] // bad in the sense that they failed for validation or data quality reasons, but not a fatal error that would cause a re-try, such as an error while interacting with an AWS resource
-        const recordGenerator = function* () {
-          for (let i = 0; i < kinesisEvent.Records.length; i++) {
-            const record = kinesisEvent.Records[i]
-            if (
-              record.kinesis &&
-              record.kinesis.data
-            ) {
-              let parsed
-              try {
-                const payload = new Buffer(record.kinesis.data, 'base64').toString()
-                console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
-                parsed = JSON.parse(payload)
-              } catch (ex) {
-                badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
-              }
-              if (parsed) {
-                const recordError = yield this.processEvent(parsed)
-                if (recordError) {
-                  badMessages.push(recordError)
-                }
-              }
-            } else {
-              badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
-            }
-          }
-        }
-        this.it = recordGenerator()
+        this.it = this.recordGenerator(kinesisEvent)
         this.it.next()
       } else {
         callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -1,0 +1,193 @@
+'use strict'
+
+const AJV = require('ajv')
+const aws = require('aws-sdk')
+
+const constants = {
+  // generic reference to self in error messages
+  MODULE: 'Kinesis Handler',
+  // methods
+  METHOD_PROCESS_EVENT: 'processEvent',
+  METHOD_PROCESS_KINESIS_EVENT: 'processKinesisEvent',
+  // errors
+  BAD_MSG: 'bad msg:', // These messages aren't bad, so much as misunderstood (not validating with a known schema).  TODO make class of Errors.
+}
+
+function makeSchemaId(schema) {
+  return `${schema.self.vendor}/${schema.self.name}/${schema.self.version}`
+}
+
+module.exports = KinesisHandler
+
+/**
+ * Example Kinesis Event Batch:
+ * {
+ *   "Records": [
+ *     {
+ *       "kinesis": {
+ *         "kinesisSchemaVersion": "1.0",
+ *         "partitionKey": "undefined",
+ *         "sequenceNumber": "49568749374218235080373793662003016116473266703358230578",
+ *         "data": "eyJzY2hlbWEiOiJjb20ubm9yZHN0cm9tL3JldGFpb[...]Y3NDQiLCJjYXRlZ29yeSI6IlN3ZWF0ZXJzIGZvciBNZW4ifX0=",
+ *         "approximateArrivalTimestamp": 1484245766.362
+ *       },
+ *       "eventSource": "aws:kinesis",
+ *       "eventVersion": "1.0",
+ *       "eventID": "shardId-000000000003:49568749374218235080373793662003016116473266703358230578",
+ *       "eventName": "aws:kinesis:record",
+ *       "invokeIdentityArn": "arn:aws:iam::515126931066:role/devProductCatalogReaderWriter",
+ *       "awsRegion": "us-west-2",
+ *       "eventSourceARN": "arn:aws:kinesis:us-west-2:515126931066:stream/devRetailStream"
+ *     },
+ *     {
+ *       "kinesis": {
+ *         "kinesisSchemaVersion": "1.0",
+ *         "partitionKey": "undefined",
+ *         "sequenceNumber": "49568749374218235080373793662021150003767486140978823218",
+ *         "data": "eyJzY2hlbWEiOiJjb20ubm9yZHN0cm9tL3JldGFpb[...]I3MyIsImNhdGVnb3J5IjoiU3dlYXRlcnMgZm9yIE1lbiJ9fQ==",
+ *         "approximateArrivalTimestamp": 1484245766.739
+ *       },
+ *       "eventSource": "aws:kinesis",
+ *       "eventVersion": "1.0",
+ *       "eventID": "shardId-000000000003:49568749374218235080373793662021150003767486140978823218",
+ *       "eventName": "aws:kinesis:record",
+ *       "invokeIdentityArn": "arn:aws:iam::515126931066:role/devProductCatalogReaderWriter",
+ *       "awsRegion": "us-west-2",
+ *       "eventSourceARN": "arn:aws:kinesis:us-west-2:515126931066:stream/devRetailStream"
+ *     }
+ *   ]
+ * }
+ * Creates Kinesis Handler instance.
+ * Usage: `KinesisHandler(schema, parallel)`
+ * @param schema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
+ * @param synch Default is false.  If true, process batches of Kinesis events synchronously, maintaining the order within each batch.  Otherwise, process batches asynchronously, in parallel.
+ * @param moduleName The name by which the module instantiating this instance is referred to in error messages.
+ * @return {Object} Kinesis handler instance
+ */
+function KinesisHandler(schema, synch, moduleName) {
+  if (!schema) {
+    throw new Error('A schema for the event data on the Kinesis stream must be provided to this handler.')
+  }
+
+  // set parameters as configured for the instance and initialize pairs mapping for the instance
+  this.eventSchemaId = makeSchemaId(schema)
+  this.synch = synch
+  this.module = moduleName && (moduleName !== '') ? moduleName : this.module
+  this.schemaMethodPairs = {}
+
+  // set up validator and add event schema to validator
+  this.ajv = new AJV()
+  this.ajv.addSchema(schema, this.eventSchemaId)
+
+  // attach methods directly called by instantiator
+  this.registerSchemaMethodPair = registerSchemaMethodPair
+  this.handler = processKinesisEvent
+
+  /**
+   * Registers a schema and method pair.
+   * @param schema The json schema for the data that triggers the calling of the provided method.
+   * @param method The method to invoke on validating to the given schema, must be of the form (event, complete) => {}.  TODO enforce this.
+   */
+  function registerSchemaMethodPair(schema, method) {
+    const schemaId = makeSchemaId(schema)
+    this.ajv.addSchema(schema, schemaId)
+    this.schemaMethodPairs[schemaId] = method
+  }
+
+  /**
+   * Process the given event, reporting failure or success to the given callback
+   * @param event The event to validate and process with the appropriate logic
+   * @param complete The callback with which to report any errors
+   */
+  function processEvent(event, complete) {
+    if (!event || !event.schema) {
+      complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not specify a schema.`)
+    } else if (event.schema !== this.eventSchemaId) {
+      complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not have proper schema.  Observed: '${event.schema}' expected: '${this.eventSchemaId}'`)
+    } else if (!ajv.validate(this.eventSchemaId, event)) {
+      complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${this.eventSchemaId}' schema.  Errors: ${ajv.errorsText()}`)
+    } else if (Object.keys(this.schemaMethodPairs).indexOf(event.data.schema) > -1) {
+      if (!ajv.validate(event.data.schema, event.data)) {
+        complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${event.data.schema}' schema. Errors: ${ajv.errorsText()}`)
+      } else {
+        this.schemaMethodPairs[event.data.schema](event, complete)
+      }
+    } else {
+      // TODO remove console.log and pass the above message once we are only receiving subscribed events
+      console.log(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} - event with unsupported data schema (${event.data.schema}) observed.`)
+      complete()
+    }
+  }
+
+    /**
+     * @param kinesisEvent The Kinesis event to decode and process.
+     * @param context The Lambda context object.
+     * @param callback The callback with which to call with results of event processing.
+     */
+    function processKinesisEvent(kinesisEvent, context, callback) {
+      if (this.synch) {
+        console.log('TODO implement synchronous batch handling.')
+      } else {
+        try {
+          console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
+          if (
+            kinesisEvent &&
+            kinesisEvent.Records &&
+            Array.isArray(kinesisEvent.Records)
+          ) {
+            let successes = 0
+            const complete = (err) => {
+              if (err) {
+                console.log(err)
+                // TODO uncomment following
+                // throw new Error(`${this.module} ${err}`);
+                // TODO remove rest of block to use above.
+                const msg = `${this.module} ${err}`
+                if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
+                  console.log('######################################################################################')
+                  console.log(msg)
+                  console.log('######################################################################################')
+                  successes += 1
+                } else {
+                  throw new Error(msg)
+                }
+              } else {
+                successes += 1
+              }
+              if (successes === kinesisEvent.Records.length) {
+                console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
+                callback()
+              }
+            }
+            for (let i = 0; i < kinesisEvent.Records.length; i++) {
+              const record = kinesisEvent.Records[i]
+              if (
+                record.kinesis &&
+                record.kinesis.data
+              ) {
+                let parsed
+                try {
+                  const payload = new Buffer(record.kinesis.data, 'base64').toString()
+                  console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
+                  parsed = JSON.parse(payload)
+                } catch (ex) {
+                  complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
+                }
+                if (parsed) {
+                  impl.processEvent(parsed, complete)
+                }
+              } else {
+                complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
+              }
+            }
+          } else {
+            callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
+          }
+        } catch (ex) {
+          console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
+          callback(ex)
+        }
+      }
+    }
+}
+

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -88,8 +88,6 @@ function KinesisHandler(eventSchema, moduleName) {
 
     if (typeof method !== 'function' || method.length !== 2) {
       throw new Error('Method must be a function of the form (event, callback) => { . . . }')
-    } else { // TODO remove
-      console.log(`OK: Method for ${schemaId} is a function with two parameters.`)
     }
     this.schemaMethodPairs[schemaId] = method
   }
@@ -218,8 +216,6 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
 
     if (typeof method !== 'function' || method.length !== 2) {
       throw new Error('Method must be a function of the form (event, callback) => { . . . }')
-    } else { // TODO remove
-      console.log(`OK: Method for ${schemaId} is a function with two parameters.`)
     }
     this.schemaMethodPairs[schemaId] = method
   }

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -69,7 +69,7 @@ function KinesisHandler(eventSchema, synch, moduleName) {
   // set parameters as configured for the instance and initialize pairs mapping for the instance
   this.eventSchemaId = makeSchemaId(eventSchema)
   this.synch = synch
-  this.module = moduleName && (moduleName !== '') ? moduleName : this.module
+  this.module = moduleName && (moduleName !== '') ? moduleName : constants.MODULE
   this.schemaMethodPairs = {}
 
   // set up validator and add event schema to validator
@@ -167,7 +167,7 @@ function KinesisHandler(eventSchema, synch, moduleName) {
                 complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
               }
               if (parsed) {
-                processEvent(parsed, complete)
+                this.processEvent(parsed, complete)
               }
             } else {
               complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
@@ -183,9 +183,9 @@ function KinesisHandler(eventSchema, synch, moduleName) {
     }
   }
 
-  // attach methods directly called by instantiator
+  this.processEvent = processEvent
   this.registerSchemaMethodPair = registerSchemaMethodPair
-  this.handler = processKinesisEvent
+  this.processKinesisEvent = processKinesisEvent
 }
 
 module.exports = KinesisHandler

--- a/lib/kinesis-handler.js
+++ b/lib/kinesis-handler.js
@@ -54,21 +54,22 @@ function makeSchemaId(schema) {
  *     }
  *   ]
  * }
- * Creates Kinesis Handler instance.
- * Usage: `KinesisHandler(eventSchema, synch, moduleName)`
- * @param eventSchema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
- * @param synch Default is false.  If true, process batches of Kinesis events synchronously, maintaining the order within each batch.  Otherwise, process batches asynchronously, in parallel.
- * @param moduleName The name by which the module instantiating this instance is referred to in error messages.
- * @return {Object} Kinesis handler instance
  */
-function KinesisHandler(eventSchema, synch, moduleName) {
+
+/**
+ * Processes batched Kinesis events in parallel.
+ * Usage: `KinesisHandler(eventSchema, moduleName)`
+ * @param eventSchema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
+ * @param moduleName The name by which the module instantiating this instance is referred to in error messages.
+ * @return {Object} Kinesis Handler instance
+ */
+function KinesisHandler(eventSchema, moduleName) {
   if (!eventSchema) {
     throw new Error('A schema for the event data on the Kinesis stream must be provided to this handler.')
   }
 
   // set parameters as configured for the instance and initialize pairs mapping for the instance
   this.eventSchemaId = makeSchemaId(eventSchema)
-  this.synch = synch
   this.module = moduleName && (moduleName !== '') ? moduleName : constants.MODULE
   this.schemaMethodPairs = {}
 
@@ -81,7 +82,7 @@ function KinesisHandler(eventSchema, synch, moduleName) {
    * @param schema The json schema for the data that triggers the calling of the provided method.
    * @param method The method to invoke on validating to the given schema, must be of the form (event, complete) => {}.  TODO enforce this.
    */
-  function registerSchemaMethodPair(schema, method) {
+  this.registerSchemaMethodPair = function (schema, method) {
     const schemaId = makeSchemaId(schema)
     this.ajv.addSchema(schema, schemaId)
     this.schemaMethodPairs[schemaId] = method
@@ -92,7 +93,8 @@ function KinesisHandler(eventSchema, synch, moduleName) {
    * @param event The event to validate and process with the appropriate logic
    * @param complete The callback with which to report any errors
    */
-  function processEvent(event, complete) {
+
+  this.processEvent = function (event, complete) {
     if (!event || !event.schema) {
       complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not specify a schema.`)
     } else if (event.schema !== this.eventSchemaId) {
@@ -117,41 +119,155 @@ function KinesisHandler(eventSchema, synch, moduleName) {
    * @param context The Lambda context object.
    * @param callback The callback with which to call with results of event processing.
    */
-  function processKinesisEvent(kinesisEvent, context, callback) {
-    if (this.synch) {
-      console.log('TODO implement synchronous batch handling.')
-    } else {
-      try {
-        console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
-        if (
-          kinesisEvent &&
-          kinesisEvent.Records &&
-          Array.isArray(kinesisEvent.Records)
-        ) {
-          let successes = 0
-          const complete = (err) => {
-            if (err) {
-              console.log(err)
-              // TODO uncomment following
-              // throw new Error(`${this.module} ${err}`);
-              // TODO remove rest of block to use above.
-              const msg = `${this.module} ${err}`
-              if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
-                console.log('######################################################################################')
-                console.log(msg)
-                console.log('######################################################################################')
-                successes += 1
-              } else {
-                throw new Error(msg)
-              }
-            } else {
+
+  this.processKinesisEvent = function (kinesisEvent, context, callback) {
+    try {
+      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
+      if (
+        kinesisEvent &&
+        kinesisEvent.Records &&
+        Array.isArray(kinesisEvent.Records)
+      ) {
+        let successes = 0
+        const complete = (err) => {
+          if (err) {
+            console.log(err)
+            // TODO uncomment following
+            // throw new Error(`${this.module} ${err}`);
+            // TODO remove rest of block to use above.
+            const msg = `${this.module} ${err}`
+            if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
+              console.log('######################################################################################')
+              console.log(msg)
+              console.log('######################################################################################')
               successes += 1
+            } else {
+              throw new Error(msg)
             }
-            if (successes === kinesisEvent.Records.length) {
-              console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
-              callback()
-            }
+          } else {
+            successes += 1
           }
+          if (successes === kinesisEvent.Records.length) {
+            console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
+            callback()
+          }
+        }
+        for (let i = 0; i < kinesisEvent.Records.length; i++) {
+          const record = kinesisEvent.Records[i]
+          if (
+            record.kinesis &&
+            record.kinesis.data
+          ) {
+            let parsed
+            try {
+              const payload = new Buffer(record.kinesis.data, 'base64').toString()
+              console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
+              parsed = JSON.parse(payload)
+            } catch (ex) {
+              complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
+            }
+            if (parsed) {
+              this.processEvent(parsed, complete)
+            }
+          } else {
+            complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
+          }
+        }
+      } else {
+        callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
+      }
+    } catch (ex) {
+      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
+      callback(ex)
+    }
+  }
+}
+
+/**
+ * Processes batches of Kinesis events synchronously, maintaining the order within each batch.
+ * Usage: `KinesisSynchronousHandler(eventSchema, moduleName)`
+ * @param eventSchema The json schema for the events on the Kinesis stream.  (Used to validate kinesis.data in one of the records in the above sample Kinesis batch.)
+ * @param moduleName The name by which the module instantiating this instance is referred to in error messages.
+ * @return {Object} Kinesis Synchronous Handler instance
+ */
+function KinesisSynchronousHandler(eventSchema, moduleName) {
+  if (!eventSchema) {
+    throw new Error('A schema for the event data on the Kinesis stream must be provided to this handler.')
+  }
+
+  // set parameters as configured for the instance and initialize pairs mapping for the instance
+  this.eventSchemaId = makeSchemaId(eventSchema)
+  this.module = moduleName && (moduleName !== '') ? moduleName : constants.MODULE
+  this.schemaMethodPairs = {}
+  this.it = null
+
+  // set up validator and add event schema to validator
+  this.ajv = new AJV()
+  this.ajv.addSchema(eventSchema, this.eventSchemaId)
+
+  /**
+   * Registers a schema and method pair.
+   * @param schema The json schema for the data that triggers the calling of the provided method.
+   * @param method The method to invoke on validating to the given schema, must be of the form (event, complete) => {}.  TODO enforce this.
+   */
+  this.registerSchemaMethodPair = function (schema, method) {
+    const schemaId = makeSchemaId(schema)
+    this.ajv.addSchema(schema, schemaId)
+    this.schemaMethodPairs[schemaId] = method
+  }
+
+  /**
+   * Process the given event, reporting any error through the iterator.  Called by a generator.
+   * @param event The event to validate and process with the appropriate logic
+   * @param complete The callback with which to report any errors
+   */
+  this.processEvent = function (event) {
+    const that = this
+    // NB we need a setTimeout to defer the call to it.next until *later*, when the generator actually reaches a paused state, after completing the current thread of execution through processEvent
+    if (!event || !event.schema) {
+      setTimeout(() => that.it.next(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not specify a schema.`), 0)
+    } else if (event.schema !== this.eventSchemaId) {
+      setTimeout(() => that.it.next(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} event did not have proper schema.  Observed: '${event.schema}' expected: '${this.eventSchemaId}'`), 0)
+    } else if (!this.ajv.validate(this.eventSchemaId, event)) {
+      setTimeout(() => that.it.next(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${this.eventSchemaId}' schema.  Errors: ${this.ajv.errorsText()}`), 0)
+    } else if (Object.keys(this.schemaMethodPairs).indexOf(event.data.schema) > -1) {
+      if (!this.ajv.validate(event.data.schema, event.data)) {
+        setTimeout(() => that.it.next(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} could not validate event to '${event.data.schema}' schema. Errors: ${this.ajv.errorsText()}`), 0)
+      } else {
+        this.schemaMethodPairs[event.data.schema](event, (err) => {
+          if (err) {
+            console.log('Fatal error while processing. ', err)
+            throw new Error(`${this.module} ${err}`) // could have the iterator throw this back to yield, but not much point having it there than here, since these are not being handled (except by re-try)
+          } else {
+            // console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
+            that.it.next()
+          }
+        })
+      }
+    } else {
+      setTimeout(() => {
+        // This is not a bad message; it's just not anything we care about.
+        console.log(`${this.module} ${constants.METHOD_PROCESS_EVENT} - skipping event with unsupported data schema (${event.data.schema}).`)
+        that.it.next()
+      }, 0)
+    }
+  }
+
+  /**
+   * @param kinesisEvent The Kinesis event to decode and process.
+   * @param context The Lambda context object.
+   * @param callback The callback with which to call with results of event processing.
+   */
+  this.processKinesisEvent = function (kinesisEvent, context, callback) {
+    try {
+      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
+      if (
+        kinesisEvent &&
+        kinesisEvent.Records &&
+        Array.isArray(kinesisEvent.Records)
+      ) {
+        const badMessages = [] // bad in the sense that they failed for validation or data quality reasons, but not a fatal error that would cause a re-try, such as an error while interacting with an AWS resource
+        const recordGenerator = function* () {
           for (let i = 0; i < kinesisEvent.Records.length; i++) {
             const record = kinesisEvent.Records[i]
             if (
@@ -164,28 +280,32 @@ function KinesisHandler(eventSchema, synch, moduleName) {
                 console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
                 parsed = JSON.parse(payload)
               } catch (ex) {
-                complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
+                badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
               }
               if (parsed) {
-                this.processEvent(parsed, complete)
+                const recordError = yield this.processEvent(parsed)
+                if (recordError) {
+                  badMessages.push(recordError)
+                }
               }
             } else {
-              complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
+              badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} record missing Kinesis data.`)
             }
           }
-        } else {
-          callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
         }
-      } catch (ex) {
-        console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
-        callback(ex)
+        this.it = recordGenerator()
+        this.it.next()
+      } else {
+        callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
       }
+    } catch (ex) {
+      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
+      callback(ex)
     }
   }
-
-  this.processEvent = processEvent
-  this.registerSchemaMethodPair = registerSchemaMethodPair
-  this.processKinesisEvent = processKinesisEvent
 }
 
-module.exports = KinesisHandler
+module.exports = {
+  KinesisHandler,
+  KinesisSynchronousHandler,
+}

--- a/lib/kinesisHandler.js
+++ b/lib/kinesisHandler.js
@@ -4,7 +4,7 @@ const AJV = require('ajv')
 
 const constants = {
   // generic reference to self in error messages
-  MODULE: 'Kinesis Handler',
+  MODULE: 'lib/kinesisHandler.js',
   // methods
   METHOD_PROCESS_EVENT: 'processEvent',
   METHOD_PROCESS_KINESIS_EVENT: 'processKinesisEvent',
@@ -70,7 +70,7 @@ function KinesisHandler(eventSchema, moduleName) {
 
   // set parameters as configured for the instance and initialize pairs mapping for the instance
   this.eventSchemaId = makeSchemaId(eventSchema)
-  this.module = moduleName && (moduleName !== '') ? moduleName : constants.MODULE
+  this.module = moduleName && (moduleName !== '') ? moduleName : 'unnamed module'
   this.schemaMethodPairs = {}
 
   // set up validator and add event schema to validator
@@ -112,7 +112,7 @@ function KinesisHandler(eventSchema, moduleName) {
         this.schemaMethodPairs[event.data.schema](event, complete)
       }
     } else {
-      console.log(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} - event with unsupported data schema (${event.data.schema}) observed.`)
+      console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} - event with unsupported data schema (${event.data.schema}) observed.`)
       complete()
     }
   }
@@ -125,7 +125,7 @@ function KinesisHandler(eventSchema, moduleName) {
 
   this.processKinesisEvent = function (kinesisEvent, context, callback) {
     try {
-      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
+      console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
       if (
         kinesisEvent &&
         kinesisEvent.Records &&
@@ -135,8 +135,8 @@ function KinesisHandler(eventSchema, moduleName) {
         const complete = (err) => {
           if (err) {
             console.log(err)
-            const msg = `${this.module} ${err}`
-            if (msg.indexOf(`${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
+            const msg = `${constants.MODULE} for ${this.module} ${err}`
+            if (msg.indexOf(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG}`) !== -1) {
               console.log('######################################################################################')
               console.log(msg)
               console.log('######################################################################################')
@@ -148,7 +148,7 @@ function KinesisHandler(eventSchema, moduleName) {
             successes += 1
           }
           if (successes === kinesisEvent.Records.length) {
-            console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
+            console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - all ${kinesisEvent.Records.length} events processed successfully.`)
             callback()
           }
         }
@@ -161,7 +161,7 @@ function KinesisHandler(eventSchema, moduleName) {
             let parsed
             try {
               const payload = new Buffer(record.kinesis.data, 'base64').toString()
-              console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
+              console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
               parsed = JSON.parse(payload)
             } catch (ex) {
               complete(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
@@ -174,10 +174,10 @@ function KinesisHandler(eventSchema, moduleName) {
           }
         }
       } else {
-        callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
+        callback(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
       }
     } catch (ex) {
-      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
+      console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
       callback(ex)
     }
   }
@@ -197,7 +197,7 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
 
   // set parameters as configured for the instance and initialize pairs mapping for the instance
   this.eventSchemaId = makeSchemaId(eventSchema)
-  this.module = moduleName && (moduleName !== '') ? moduleName : constants.MODULE
+  this.module = moduleName && (moduleName !== '') ? moduleName : 'unnamed module'
   this.schemaMethodPairs = {}
   this.it = null
 
@@ -240,9 +240,9 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
         this.schemaMethodPairs[event.data.schema](event, (err) => {
           if (err) {
             console.log('Fatal error while processing. ', err)
-            throw new Error(`${this.module} ${err}`) // could have the iterator throw this back to yield, but not much point having it there than here, since these are not being handled (except by re-try)
+            throw new Error(`${constants.MODULE} for ${this.module} ${err}`) // could have the iterator throw this back to yield, but not much point having it there than here, since these are not being handled (except by re-try)
           } else {
-            console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - one ${event.data.schema} event processed successfully.`)
+            console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - one ${event.data.schema} event processed successfully.`)
             that.it.next()
           }
         })
@@ -250,7 +250,7 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
     } else {
       setTimeout(() => {
         // This is not a bad message; it's just not anything we care about.
-        console.log(`${this.module} ${constants.METHOD_PROCESS_EVENT} - skipping event with unsupported data schema (${event.data.schema}).`)
+        console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_EVENT} - skipping event with unsupported data schema (${event.data.schema}).`)
         that.it.next()
       }, 0)
     }
@@ -271,7 +271,7 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
         let parsed
         try {
           const payload = new Buffer(record.kinesis.data, 'base64').toString()
-          console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
+          console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - payload: ${payload}`)
           parsed = JSON.parse(payload)
         } catch (ex) {
           badMessages.push(`${constants.METHOD_PROCESS_EVENT} ${constants.BAD_MSG} failed to decode and parse the data - "${ex.stack}".`)
@@ -296,7 +296,7 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
    */
   this.processKinesisEvent = function (kinesisEvent, context, callback) {
     try {
-      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`)
+      console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - Kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`) // TODO remove
       if (
         kinesisEvent &&
         kinesisEvent.Records &&
@@ -305,10 +305,10 @@ function KinesisSynchronousHandler(eventSchema, moduleName) {
         this.it = this.recordGenerator(kinesisEvent)
         this.it.next()
       } else {
-        callback(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
+        callback(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - no records received.`)
       }
     } catch (ex) {
-      console.log(`${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
+      console.log(`${constants.MODULE} for ${this.module} ${constants.METHOD_PROCESS_KINESIS_EVENT} - exception: ${ex.stack}`)
       callback(ex)
     }
   }

--- a/lib/kinesisHandler.spec.js
+++ b/lib/kinesisHandler.spec.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/* eslint-env node, mocha */
+
+// const expect = require('chai').expect;
+
+// const catalog = require('./kinesisHandler.js');
+
+describe('Kinesis Handler Unit Tests', () => {
+  let consoleLog
+  before(() => {
+    consoleLog = console.log
+    console.log = () => {}
+  })
+  after(() => {
+    console.log = consoleLog
+  })
+  it('should have some tests', () => {
+  })
+})

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   },
   "homepage": "https://github.com/Nordstrom/kinesis-handler#readme",
   "dependencies": {
-    "ajv": "^4.11.2",
-    "aws-sdk": "^2.5.0"
+    "ajv": "^4.11.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "kinesis-handler",
   "version": "0.0.1",
   "description": "Registers schema-method pairs, then calls method when event data matching the schema is detected on the kinesis stream.",
-  "main": "lib/kinesis-handler",
+  "main": "lib/kinesisHandler",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Nordstrom/kinesis-handler.git"
   },
   "scripts": {
+    "test": "./node_modules/.bin/mocha --recursive -R min ./**/*.spec.js",
     "lint": "./node_modules/.bin/eslint ./**/*.js"
   },
   "keywords": [
@@ -26,7 +27,6 @@
     "ajv": "^4.11.2"
   },
   "devDependencies": {
-    "babel-eslint": "^7.2.1",
     "chai": "^3.5.0",
     "eslint": "^3.8.1",
     "eslint-config-airbnb": "^12.0.0",
@@ -38,6 +38,7 @@
     "pre-commit": "^1.1.3"
   },
   "pre-commit": [
+    "test",
     "lint"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "kinesis-handler",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Registers schema-method pairs, then calls method when event data matching the schema is detected on the kinesis stream.",
-  "main": "index.js",
+  "main": "lib/kinesis-handler",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Nordstrom/kinesis-handler.git"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive -R min ./**/*.spec.js",
     "lint": "./node_modules/.bin/eslint ./**/*.js"
   },
   "keywords": [
@@ -28,6 +27,7 @@
     "aws-sdk": "^2.5.0"
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.1",
     "chai": "^3.5.0",
     "eslint": "^3.8.1",
     "eslint-config-airbnb": "^12.0.0",
@@ -39,7 +39,6 @@
     "pre-commit": "^1.1.3"
   },
   "pre-commit": [
-    "test",
     "lint"
   ]
 }


### PR DESCRIPTION
Kinesis handler into module (ENG-2164) and synchronous handler added (ENG-2283).

The parallel one is KinesisHandler.  The synchronous is KinesisSynchronousHandler.

Require kinesis-handler, instantiate whichever handler you need, passing it an ingress or egress schema and the name of the module using it (for error messaging), then register additional data schemas and methods to execute on validation.  The handler to give to the lambda is still named processKinesisEvent.